### PR TITLE
feat: Add AWS Key Pair Terraform module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ provider "aws" {
   region = "us-east-1"
 }
 
-module "s3_bucket" {
+module "aws_s3_bucket" {
   source = "./modules/aws-s3-bucket"
 
   bucket_name = var.bucket_name
@@ -21,3 +21,10 @@ module "s3_bucket" {
 }
 
 
+module "aws_key_pair" {
+  source = "./modules/aws-key-pair"
+
+  key_name        = var.key_name
+  public_key_path = var.public_key_path
+  environment     = var.environment
+}

--- a/modules/aws-key-pair/README.md
+++ b/modules/aws-key-pair/README.md
@@ -1,0 +1,35 @@
+# Overview
+
+This modules creates an AWS EC2 key pair using the provided public key. The key can be used to securely access EC2 instances.
+
+### Usage
+
+```hcl
+module "key_pair" {
+  source          = "./modules/aws-key-pair"
+  key_name        = "my-key-pair"
+  public_key_path = "~/.ssh/id_rsa.pub"
+  environment     = "dev"
+}
+```
+
+### Inputs
+
+| Name              | Description                                | Type   | Default | Required |
+| ----------------- | ------------------------------------------ | ------ | ------- | -------- |
+| `key_name`        | The name for the key pair                  | string | n/a     | yes      |
+| `public_key_path` | Path to the public key file                | string | n/a     | yes      |
+| `environment`     | The environment (e.g., dev, staging, prod) | string | n/a     | yes      |
+
+### Outputs
+
+| Name          | Description                      |
+| ------------- | -------------------------------- |
+| `key_name`    | The name of the created key pair |
+| `key_pair_id` | The ID of the created key pair   |
+
+### Notes
+
+- Ensure that the public key file exists at the specified path before applying this module.
+- The public key should be in the OpenSSH public key format.
+- AWS does not return the private key, so make sure to keep your local private key secure.

--- a/modules/aws-key-pair/main.tf
+++ b/modules/aws-key-pair/main.tf
@@ -1,0 +1,10 @@
+
+resource "aws_key_pair" "this" {
+  key_name   = var.key_name
+  public_key = file(var.public_key_path)
+
+  tags = {
+    Name        = var.key_name
+    Environment = var.environment
+  }
+}

--- a/modules/aws-key-pair/outputs.tf
+++ b/modules/aws-key-pair/outputs.tf
@@ -1,0 +1,11 @@
+
+output "key_name" {
+  description = "The name of the created key pair"
+  value       = aws_key_pair.this.key_name
+}
+
+output "key_pair_id" {
+  description = "The ID of the created key pair"
+  value       = aws_key_pair.this.key_pair_id
+}
+

--- a/modules/aws-key-pair/variables.tf
+++ b/modules/aws-key-pair/variables.tf
@@ -1,0 +1,15 @@
+
+variable "key_name" {
+  description = "The name for the key pair"
+  type        = string
+}
+
+variable "public_key_path" {
+  description = "Path to the public key file"
+  type        = string
+}
+
+variable "environment" {
+  description = "The environment (e.g. dev, stage, prod)"
+  type        = string
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,12 +1,20 @@
 
 output "bucket_id" {
-  value = module.s3_bucket.bucket_id
+  value = module.aws_s3_bucket.bucket_id
 }
 
 output "bucket_arn" {
-  value = module.s3_bucket.bucket_arn
+  value = module.aws_s3_bucket.bucket_arn
 }
 
 output "website_endpoint" {
-  value = module.s3_bucket.website_endpoint
+  value = module.aws_s3_bucket.website_endpoint
+}
+
+output "key_name" {
+  value = module.aws_key_pair.key_name
+}
+
+output "key_pair_id" {
+  value = module.aws_key_pair.key_pair_id
 }

--- a/variables.tf
+++ b/variables.tf
@@ -13,3 +13,12 @@ variable "environment" {
   type        = string
 }
 
+variable "key_name" {
+  description = "The name for the key pair"
+  type        = string
+}
+
+variable "public_key_path" {
+  description = "Path to the public key file"
+  type        = string
+}


### PR DESCRIPTION
- Create main.tf with aws_key_pair resource
- Define input variables for key name, public key path, and environment
- Add outputs for key name and key pair ID
- Include README with usage instruction and module details
- Instegrate with existing project structure under modules/aws-key-pair/